### PR TITLE
hw 4

### DIFF
--- a/online_inference/kube/online-inference-deployment-blue-green.yaml
+++ b/online_inference/kube/online-inference-deployment-blue-green.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  replicas: 8
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 8
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      name: online-inference
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - image: agorlenko/online_inference:v2
+          name: online-inference
+          ports:
+            - containerPort: 8000

--- a/online_inference/kube/online-inference-deployment-rolling-update.yaml
+++ b/online_inference/kube/online-inference-deployment-rolling-update.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  replicas: 8
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 2
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      name: online-inference
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - image: agorlenko/online_inference:v2
+          name: online-inference
+          ports:
+            - containerPort: 8000

--- a/online_inference/kube/online-inference-pod-probes.yaml
+++ b/online_inference/kube/online-inference-pod-probes.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  containers:
+    - image: agorlenko/online_inference:v2
+      name: online-inference
+      ports:
+        - containerPort: 8000
+      resources:
+        requests:
+          memory: "128Mi"
+          cpu: "1"
+        limits:
+          memory: "256Mi"
+          cpu: "2"
+      readinessProbe:
+        httpGet:
+          path: /health
+          port: 8000
+        initialDelaySeconds: 20
+        periodSeconds: 3
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8000
+        initialDelaySeconds: 20
+        periodSeconds: 10

--- a/online_inference/kube/online-inference-pod.yaml
+++ b/online_inference/kube/online-inference-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  containers:
+    - image: agorlenko/online_inference:v1
+      name: online-inference
+      ports:
+        - containerPort: 8000
+      resources:
+        requests:
+          memory: "128Mi"
+          cpu: "1"
+        limits:
+          memory: "256Mi"
+          cpu: "2"

--- a/online_inference/kube/online-inference-replicaset.yaml
+++ b/online_inference/kube/online-inference-replicaset.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: online-inference
 spec:
-  replicas: 8
+  replicas: 3
   selector:
     matchLabels:
       app: online-inference

--- a/online_inference/kube/online-inference-replicaset.yaml
+++ b/online_inference/kube/online-inference-replicaset.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: online-inference
+  labels:
+    app: online-inference
+spec:
+  replicas: 8
+  selector:
+    matchLabels:
+      app: online-inference
+  template:
+    metadata:
+      name: online-inference
+      labels:
+        app: online-inference
+    spec:
+      containers:
+        - image: agorlenko/online_inference:v1
+          name: online-inference
+          ports:
+            - containerPort: 8000
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "1"
+            limits:
+              memory: "256Mi"
+              cpu: "2"


### PR DESCRIPTION
1. Локально развернут minikube, 5 баллов

![image](https://user-images.githubusercontent.com/2107759/174908012-ccce1b37-98c8-4eae-9ae4-8f862e1a4d08.png)

2. pod поднялся. 4 балла

![image](https://user-images.githubusercontent.com/2107759/174908580-2a468680-64f0-4aab-af77-b58d61ff8481.png)

3. Прописаны requests/limits. Это нужно чтобы указать требуемые ресурсы и максимальные ресурсы. Исходя из этого кубер сможет подобрать подходящую ноду для пода, а также прибить под, например с оом в случае с памятью, если он начнет потреблять ресурсов больше, чем указано в limits. 2 балла.
4. Модифицировано приложение так, чтобы была задержка при старте и завершение после заданного таймаута. Добавлены Liveness и Readiness пробы. Соответсвенно, вначале под находится в статусе pending, потом, после открытия порта под становится доступным и после аварийного завершения и liveness пробы кубер его рестартит. 3 балла.
5. Создана ReplicaSet. В случае, когда мы после смены докер образа уменьшаем количество реплик, то ничего не происходит, остается версия 1. Если же увеличиваем количество, то добавляются поды уже с новой версией 2, а старые остаются с прежней версией 1. 3 балла.
6. Создан деплоймент. Рассморены 2 варианта: когда есть момент времени, когда в кластере есть как все старые, так и все новые поды (maxSurge: 8, maxUnavailable: 0) и второй вариант, когда одновременно с поднятием новых версий, гасятся старые (например maxSurge: 2, maxUnavailable: 2). 3 балла.

Итого: 20 баллов
